### PR TITLE
Fixed compiler error.

### DIFF
--- a/CoreLib/Data/SqlServer/Builders/SqlStatementBuilder.Select.cs
+++ b/CoreLib/Data/SqlServer/Builders/SqlStatementBuilder.Select.cs
@@ -95,6 +95,11 @@ public static partial class SqlStatementBuilder
 
     private struct SelectStatement : ISelectStatement
     {
+        public SelectStatement()
+        {
+            this.TableName = string.Empty;
+            this.WhereClause = this.OrderBy = this.OrderByColumn = null;
+        }
         public string TableName { get; set; }
         public string? WhereClause { get; set; }
         public string? OrderBy { get; set; }


### PR DESCRIPTION
Severity Code Description Project File Line Suppression State
Error CS0843 Auto-implemented property 'SqlStatementBuilder.SelectStatement.TableName' must be fully assigned before control is returned to the caller. CoreLib D:\Dev\VS\Prj\Clients\HanyCo\MES20\Infra\Back\Source\Bcl\CoreLib\Data\SqlServer\Builders\SqlStatementBuilder.Select.cs 96 Active
Error CS0843 Auto-implemented property 'SqlStatementBuilder.SelectStatement.WhereClause' must be fully assigned before control is returned to the caller. CoreLib D:\Dev\VS\Prj\Clients\HanyCo\MES20\Infra\Back\Source\Bcl\CoreLib\Data\SqlServer\Builders\SqlStatementBuilder.Select.cs 96 Active
Error CS0843 Auto-implemented property 'SqlStatementBuilder.SelectStatement.OrderBy' must be fully assigned before control is returned to the caller. CoreLib D:\Dev\VS\Prj\Clients\HanyCo\MES20\Infra\Back\Source\Bcl\CoreLib\Data\SqlServer\Builders\SqlStatementBuilder.Select.cs 96 Active
Error CS0843 Auto-implemented property 'SqlStatementBuilder.SelectStatement.OrderByColumn' must be fully assigned before control is returned to the caller. CoreLib D:\Dev\VS\Prj\Clients\HanyCo\MES20\Infra\Back\Source\Bcl\CoreLib\Data\SqlServer\Builders\SqlStatementBuilder.Select.cs 96 Active