### PR TITLE
Create a class to wrap up .NET ILogger's performance bottleneck

### DIFF
--- a/CoreLib/Helpers/LoggingHelper.cs
+++ b/CoreLib/Helpers/LoggingHelper.cs
@@ -1,8 +1,7 @@
 ﻿using Library.Globalization.Helpers;
 using Library.Logging;
-using MsLogLevel = Microsoft.Extensions.Logging.LogLevel;
-namespace Library.Helpers;
 
+namespace Library.Helpers;
 public static class LoggingHelper
 {
     public static bool MeetsLevel(this LogLevel level, LogLevel minLevel)

--- a/CoreLib/Logging/DbCrudLogger.cs
+++ b/CoreLib/Logging/DbCrudLogger.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Library.Logging;
+
+public interface IDbCrudLogger : IMsLoggerMessageWapper
+{
+    void ItemAdded(string log);
+    void ItemAddFail(string log, Exception? exception = null);
+    void ItemDeleted(string log);
+    void ItemDeleteFail(string log, Exception? exception = null);
+    void ItemUpdated(string log);
+    void ItemUpdateFail(string log, Exception? exception = null);
+}
+
+public class DbCrudLogger : MsLoggerMessageWapperBase, IDbCrudLogger
+{
+    private readonly Action<IMsLogger, string, Exception?> _itemAdded;
+    private readonly Action<IMsLogger, string, Exception?> _itemAddFail;
+
+    private readonly Action<IMsLogger, string, Exception?> _itemUpdated;
+    private readonly Action<IMsLogger, string, Exception?> _itemUpdateFail;
+
+    private readonly Action<IMsLogger, string, Exception?> _itemDeleted;
+    private readonly Action<IMsLogger, string, Exception?> _itemDeleteFail;
+
+    public DbCrudLogger(IMsLogger logger, string name, int eventId)
+        : base(logger, name, eventId)
+    {
+        this._itemAdded = LoggerMessage.Define<string>(MsLogLevel.Information, new EventId(eventId, name), "Item added: {item}");
+        this._itemAddFail = LoggerMessage.Define<string>(MsLogLevel.Error, new EventId(eventId, name), "item add fail: {item}");
+
+        this._itemUpdated = LoggerMessage.Define<string>(MsLogLevel.Information, new EventId(eventId, name), "item updated: {item}");
+        this._itemUpdateFail = LoggerMessage.Define<string>(MsLogLevel.Error, new EventId(eventId, name), "item update fail: {item}");
+
+        this._itemDeleted = LoggerMessage.Define<string>(MsLogLevel.Information, new EventId(eventId, name), "item deleted: {item}");
+        this._itemDeleteFail = LoggerMessage.Define<string>(MsLogLevel.Error, new EventId(eventId, name), "item delete fail: {item}");
+    }
+
+    public void ItemAdded(string log) => this._itemAdded(this._logger, log, null);
+    public void ItemAddFail(string log, Exception? exception = null) => this._itemAddFail(this._logger, log, exception);
+
+    public void ItemUpdated(string log) => this._itemUpdated(this._logger, log, null);
+    public void ItemUpdateFail(string log, Exception? exception = null) => this._itemUpdateFail(this._logger, log, exception);
+
+    public void ItemDeleted(string log) => this._itemDeleted(this._logger, log, null);
+    public void ItemDeleteFail(string log, Exception? exception = null) => this._itemDeleteFail(this._logger, log, exception);
+}

--- a/CoreLib/Logging/MsLoggerMessageHelper.cs
+++ b/CoreLib/Logging/MsLoggerMessageHelper.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Library.Logging;
+public static class MsLoggerMessageHelper
+{
+    private static readonly Action<IMsLogger, string, Exception?> _info
+        = LoggerMessage.Define<string>(MsLogLevel.Information, new EventId(1, nameof(Info)), "{Log}");
+    private static readonly Action<IMsLogger, string, Exception?> _debug
+        = LoggerMessage.Define<string>(MsLogLevel.Debug, new EventId(1, nameof(Debug)), "{Log}");
+    private static readonly Action<IMsLogger, string, Exception?> _error
+        = LoggerMessage.Define<string>(MsLogLevel.Error, new EventId(1, nameof(Error)), "{Log}");
+    private static readonly Action<IMsLogger, string, Exception?> _warning
+        = LoggerMessage.Define<string>(MsLogLevel.Warning, new EventId(1, nameof(Warn)), "{Log}");
+
+    public static void Info(this IMsLogger logger, string log) => _info(logger, log, null);
+    public static void Debug(this IMsLogger logger, string log) => _debug(logger, log, null);
+    public static void Error(this IMsLogger logger, string log, Exception? exception = null) => _error(logger, log, exception);
+    public static void Warn(this IMsLogger logger, string log) => _warning(logger, log, null);
+}

--- a/CoreLib/Logging/MsLoggerMessageWapper.cs
+++ b/CoreLib/Logging/MsLoggerMessageWapper.cs
@@ -1,0 +1,17 @@
+﻿namespace Library.Logging;
+
+public interface IMsLoggerMessageWapper
+{
+    void Debug(string log);
+    void Error(string log, Exception? exception = null);
+    void Info(string log);
+    void Warn(string log);
+}
+
+public class MsLoggerMessageWapper : MsLoggerMessageWapperBase, IMsLoggerMessageWapper
+{
+    public MsLoggerMessageWapper(Microsoft.Extensions.Logging.ILogger logger, string name, int eventId)
+        : base(logger, name, eventId)
+    {
+    }
+}

--- a/CoreLib/Logging/MsLoggerMessageWapperBase.cs
+++ b/CoreLib/Logging/MsLoggerMessageWapperBase.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Library.Logging;
+
+public abstract class MsLoggerMessageWapperBase
+{
+    protected readonly IMsLogger _logger;
+
+    protected readonly Action<IMsLogger, string, Exception?> _info;
+    protected readonly Action<IMsLogger, string, Exception?> _debug;
+    protected readonly Action<IMsLogger, string, Exception?> _error;
+    protected readonly Action<IMsLogger, string, Exception?> _warning;
+
+    protected MsLoggerMessageWapperBase(IMsLogger logger, string name, int eventId)
+    {
+        this._logger = logger;
+        this._info = LoggerMessage.Define<string>(MsLogLevel.Information, new EventId(eventId, name), "{Log}");
+        this._debug = LoggerMessage.Define<string>(MsLogLevel.Debug, new EventId(eventId, name), "{Log}");
+        this._error = LoggerMessage.Define<string>(MsLogLevel.Error, new EventId(eventId, name), "{Log}");
+        this._warning = LoggerMessage.Define<string>(MsLogLevel.Warning, new EventId(eventId, name), "{Log}");
+    }
+
+    public virtual void Debug(string log) => this._debug(this._logger, log, null);
+    public virtual void Error(string log, Exception? exception = null) => this._error(this._logger, log, exception);
+
+    public virtual void Info(string log) => this._info(this._logger, log, null);
+    public virtual void Warn(string log) => this._warning(this._logger, log, null);
+}

--- a/CoreLib/_globals.cs
+++ b/CoreLib/_globals.cs
@@ -3,8 +3,12 @@ global using Library.Helpers;
 global using System.Diagnostics.CodeAnalysis;
 global using static Library.Coding.CodeHelper;
 global using static Library.Coding.Functional;
-using System.Runtime.CompilerServices;
 
+global using IMsLogger = Microsoft.Extensions.Logging.ILogger;
+global using MsLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+
+using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Library.Wpf")]
 [assembly: InternalsVisibleTo("Library.Web")]
 [assembly: InternalsVisibleTo("LibraryTest")]

--- a/Tests/TestConApp/Program.Init.cs
+++ b/Tests/TestConApp/Program.Init.cs
@@ -1,19 +1,20 @@
 ﻿using System.Runtime.CompilerServices;
 using Library;
+using Library.Logging;
 using Microsoft.Extensions.Logging;
 
 namespace TestConApp;
 
 internal partial class Program
 {
-    private static ILogger _logger = null!;
+    private static Microsoft.Extensions.Logging.ILogger _logger = null!;
 
     [ModuleInitializer]
     public static void Startup()
     {
         setupLogger();
         LibLogger.AddLogger(_logger);
-        _logger.LogInformation("System initialized.");
+        _logger.Info("System initialized.");
 
         static void setupLogger()
         {
@@ -21,8 +22,9 @@ internal partial class Program
             {
                 builder.AddSimpleConsole(options =>
                 {
-                    options.IncludeScopes = true;
-                    options.TimestampFormat = "HH:mm:ss";
+                    //! Not fancy
+                    //x options.IncludeScopes = true;
+                    //x options.TimestampFormat = "HH:mm:ss";
                     options.UseUtcTimestamp = false;
                 });
             });

--- a/Tests/TestConApp/Program.cs
+++ b/Tests/TestConApp/Program.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Library.Coding;
-using Library.MultiOperation;
+﻿using Library.Logging;
 
 namespace TestConApp;
 
@@ -11,72 +6,16 @@ internal partial class Program
 {
     private static void Main(params string[] args)
     {
-        //var func1 = (int x) => x - 1;
-        //var starter = () => 5;
-        //var compose = starter.Compose(func1).Compose(func1).Compose(func1);
-        //var result = compose();
+        _logger.Info("This is info.");
+        _logger.Debug("This is debug.");
+        _logger.Error("This is error.");
+        _logger.Warn("This is warning.");
+        Test();
 
-        var starter = () => "This is a long long sentence.";
-        var compose = starter.Compose(s => $"{s} Let's add")
-                             .Compose(s => $"{s} some other")
-                             .Compose(s => $"{s} statement")
-                             .Compose(s => $"{s} to make sure")
-                             .Compose(s => $"{s} the compose method")
-                             .Compose(s => $"{s} is working")
-                             .Compose(s => $"{s} like a charm.");
-        var result = compose();
-        Console.WriteLine(result);
-        //OperationsTest();
-        //HigherOrder();
+        var w = new DbCrudLogger(_logger, "Console App", 5000);
+        w.ItemAdded("apple (1027)");
+        w.ItemUpdated("apple (1027)");
     }
 
-    private static void HigherOrder()
-    {
-        var sum = ((int? LastResult, int Current) row) => row.Current + row.LastResult ?? 0;
-        var powerOf = (int x) => (int a) => a ^ x;
-        var multiply = (int x) => (int a) => a * x;
-        var transform = (IEnumerable<int> source, Func<int, int> transformer) => source.Select(transformer);
-        var aggregate = (IEnumerable<int> source, Func<(int? LastResult, int Current), int> aggregator) =>
-        {
-            int? last = null;
-            foreach (var item in source)
-            {
-                last = aggregator((last, item));
-            }
-            return last;
-        };
-
-        var data = Enumerable.Range(0, 1001);
-
-        var powerOfThrees = transform(data, powerOf(3));
-        var multiple5s = transform(data, multiply(5));
-        var total = aggregate(data, sum); //! Not higher-ordered
-    }
-
-    private static void OperationsTest()
-    {
-        var display = (int state, int index, int count) => Console.WriteLine($"state: {state}, index: {index}, count: {count}");
-        var result = Operations.New(5)
-                               .Add((state) => 10)
-                               .Add((state, index) => 20)
-                               .Add((state, index, count) => 30)
-                               //.AsSequenctial()
-                               .Build()
-                               .Watch(display)
-                               .Run();
-        var r = Operations.New(Task.FromResult(1))
-                          .Add(state => Task.FromResult(2))
-                          .Add(state => Task.FromResult(3))
-                          .Add(state => Task.FromResult(4))
-                          .Add(state => Task.FromResult(5))
-                          .Build()
-                          .Watch((state, index, count) => Console.WriteLine(state.Id))
-                          .Run();
-        r.Wait();
-    }
-}
-
-public static class TestExtensions
-{
-
+    private static void Test() => _logger.Info("1");
 }

--- a/Tests/TestConApp/TestConApp.csproj
+++ b/Tests/TestConApp/TestConApp.csproj
@@ -17,6 +17,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\CoreLib\CoreLib.csproj" />
+	  <ProjectReference Include="..\..\WebLib\WebLib.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/WebLib/Properties/launchSettings.json
+++ b/WebLib/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "WebLib": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:63736;http://localhost:63737"
+    }
+  }
+}


### PR DESCRIPTION
`MsMessageLogger` wrapped in two classes: One for common logging, one for Database CRUD logging.